### PR TITLE
Prefer function reader syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ auto-format:
 
 ```lisp
 (add-hook 'reason-mode-hook (lambda ()
-          (add-hook 'before-save-hook 'refmt-before-save)))
+          (add-hook 'before-save-hook #'refmt-before-save)))
 ```
 
 ### Tests via Cask + ERT


### PR DESCRIPTION
While passing a function as an argument in Elisp as
'function-name works, calling #'function-name may be
preferred since its intent is more obvious.